### PR TITLE
multiple imports of a type (enum in this case) throws an exception.

### DIFF
--- a/src/poshBAR/AppPoolAdministration.ps1
+++ b/src/poshBAR/AppPoolAdministration.ps1
@@ -129,6 +129,7 @@ function Get-ModuleDirectory {
     return Split-Path $script:MyInvocation.MyCommand.Path
 }
 
+if(!("IdentityType" -as [Type])){
  Add-Type -TypeDefinition @'
     public enum IdentityType{
         LocalSystem,
@@ -138,10 +139,13 @@ function Get-ModuleDirectory {
         ApplicationPoolIdentity
     }
 '@
+}
 
+if(!("PipelineMode" -as [Type])){
  Add-Type -TypeDefinition @'
     public enum PipelineMode{
         Integrated,
         Classic
     }
 '@
+}

--- a/src/poshBAR/Install-WebApplication.ps1
+++ b/src/poshBAR/Install-WebApplication.ps1
@@ -60,6 +60,7 @@ function Install-WebApplication() {
     $msgs.msg_web_app_success -f $websiteSettings.siteName
 }
 
+if(!("AuthType" -as [Type])){
  Add-Type -TypeDefinition @'
     public enum AuthType{
         WindowsAuthentication,
@@ -68,3 +69,4 @@ function Install-WebApplication() {
         FormsAuthentication
     }
 '@
+}

--- a/src/poshBAR/Set-IISAuthentication.ps1
+++ b/src/poshBAR/Set-IISAuthentication.ps1
@@ -52,6 +52,7 @@ function Set-IISAuthentication
 
 }
 
+if(!("AuthType" -as [Type])){
  Add-Type -TypeDefinition @'
     public enum AuthType{
         WindowsAuthentication,
@@ -60,3 +61,4 @@ function Set-IISAuthentication
         FormsAuthentication
     }
 '@
+}


### PR DESCRIPTION
[CF] fixed issue where when running multiple projects, powershell would try creating another instance of the same enum.
