### PR TITLE
Fixed bug in Find-ToolPath when tool name has an exe extension and is…

### DIFF
--- a/src/poshBAR/Find-ToolPath.ps1
+++ b/src/poshBAR/Find-ToolPath.ps1
@@ -25,10 +25,11 @@ function Find-ToolPath {
     Write-Verbose "Current Directory is '$here'"
     
     # try to find it in the existing path.
-    $paths = $env:PATH.Split(';',[StringSplitOptions]::RemoveEmptyEntries)
-    Write-Verbose "Looking for '$toolName' on the `$env:PATH"
-    if($env:PATH -like "*$toolName*" ) { 
-        $foundPath = $paths | ? { $_ -like "*$toolName*" } | select -First 1
+    $toolNameWithoutExt = $toolName.Split('.')[0]
+    Write-Verbose "Looking for '$toolNameWithoutExt' on the `$env:PATH"
+    if($env:PATH -like "*$toolNameWithoutExt*" ) { 
+        $paths = $env:PATH.Split(';',[StringSplitOptions]::RemoveEmptyEntries)
+        $foundPath = $paths | ? { $_ -like "*$toolNameWithoutExt*" } | select -First 1
         Write-Verbose "Found '$toolName' in '$foundPath'"
         return $foundPath
     }

--- a/src/tests/Find-ToolPath.Tests.ps1
+++ b/src/tests/Find-ToolPath.Tests.ps1
@@ -44,6 +44,20 @@ Describe 'Find Tool Path' {
         }
     }
     
+    Context 'Will handle tool with exe extension on PATH' { 
+        # Setup 
+        $toolName = 'mock.exe'
+        $mockToolPath = 'C:\Temp\Mock'
+        $env:PATH += ";$mockToolPath"
+             
+        # execute
+        $result = Find-ToolPath $toolName  
+       
+       # assert         
+        It 'Should find a mock.exe tool on the path and not throw.' {
+            $result | should be $mockToolPath
+        }
+    }
     Context 'Will handle an invalid tool.' {
         # setup
         $toolName = 'Foo'


### PR DESCRIPTION
Fixed bug in Find-ToolPath when tool name has an exe extension and exists in path
